### PR TITLE
Don't detect with FFmpeg if mp3 is not accepted

### DIFF
--- a/mimes.go
+++ b/mimes.go
@@ -73,7 +73,6 @@ var matchers = []Matcher{
 		[]byte("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"),
 		[]byte("MThd\x00\x00\x00\x06"),
 	},
-	MatcherFunc(matchMP3),
 }
 
 var (
@@ -244,6 +243,13 @@ func detectMimeType(buf []byte, accepted map[string]bool) (
 			break
 		}
 	}
+
+	if mime == "" {
+		if accepted == nil || accepted["audio/mpeg"] {
+			mime, ext = matchMP3(buf)
+		}
+	}
+
 	switch {
 	case mime == "":
 		err = UnsupportedMIMEError("application/octet-stream")


### PR DESCRIPTION
Probing user-specified files with FFmpeg might be rather dangerous.
For example if you pass it similar input:

```
#EXTM3U
#EXT-X-MEDIA-SEQUENCE:0
#EXTINF:10.0,
http://localhost:8000/1.mp4
#EXT-X-ENDLIST
```

it will make GET request to the specified URL which might be quite
undesirable (e.g. consider website behind Cloudflare).

Of course it's not panacea, it might be still possible to come with
header which would be accepted by DetectMIME() but cause some strange
FFmpeg's demuxer behavior because we're calling avformat_open_input()
when dumping frame anyway. So another improvement would be to pass
desired demuxer from processVideo().

More details regarding FFmpeg's HLS handling:
<https://news.ycombinator.com/item?id=10893301>