### PR TITLE
Fix use of deprecated APIs

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -4,6 +4,16 @@ const int bufSize = 1 << 12;
 
 pthread_mutex_t codecMu = PTHREAD_MUTEX_INITIALIZER;
 
+void init(void) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
+	av_register_all();
+#endif
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100)
+	avcodec_register_all();
+#endif
+	av_log_set_level(16);
+}
+
 // Initialize am AVFormatContext with the buffered file
 int create_context(AVFormatContext** ctx)
 {

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -35,9 +35,7 @@ var (
 )
 
 func init() {
-	C.av_register_all()
-	C.avcodec_register_all()
-	C.av_log_set_level(16)
+	C.init()
 }
 
 // C can not retain any pointers to Go memory after the cgo call returns. We

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -5,6 +5,7 @@
 extern int readCallBack(void *, uint8_t *, int);
 extern int64_t seekCallBack(void *, int64_t, int);
 
+void init(void);
 int create_context(AVFormatContext **ctx);
 void destroy(AVFormatContext *ctx);
 int codec_context(AVCodecContext **avcc,


### PR DESCRIPTION
av_register_all and avcodec_register_all are deprecated and do nothing
in recent ffmpeg.

See: https://github.com/FFmpeg/FFmpeg/blob/1296a71/doc/APIchanges#L47-L55
See: https://github.com/FFmpeg/FFmpeg/commit/10bcc41