### PR TITLE
Do not patch GM signal handlers

### DIFF
--- a/init.c
+++ b/init.c
@@ -1,64 +1,7 @@
 #include "init.h"
 #include <magick/api.h>
-#include <signal.h>
-#include <stdio.h>
-#include <string.h>
 
 void magickInit()
 {
     InitializeMagick(NULL);
-
-#ifndef _WIN32
-
-#if defined(SIGCHLD)
-    fixSignal(SIGCHLD);
-#endif
-#if defined(SIGHUP)
-    fixSignal(SIGHUP);
-#endif
-#if defined(SIGINT)
-    fixSignal(SIGINT);
-#endif
-#if defined(SIGQUIT)
-    fixSignal(SIGQUIT);
-#endif
-#if defined(SIGABRT)
-    fixSignal(SIGABRT);
-#endif
-#if defined(SIGFPE)
-    fixSignal(SIGFPE);
-#endif
-#if defined(SIGTERM)
-    fixSignal(SIGTERM);
-#endif
-#if defined(SIGBUS)
-    fixSignal(SIGBUS);
-#endif
-#if defined(SIGSEGV)
-    fixSignal(SIGSEGV);
-#endif
-#if defined(SIGXCPU)
-    fixSignal(SIGXCPU);
-#endif
-#if defined(SIGXFSZ)
-    fixSignal(SIGXFSZ);
-#endif
-
-#endif
 }
-
-#ifndef _WIN32
-// Add the SA_ONSTACK flag to a listened on signal to play nice with the Go
-// runtime
-static void fixSignal(int signum)
-{
-    struct sigaction st;
-
-    if (sigaction(signum, NULL, &st) < 0) {
-        return;
-    }
-
-    st.sa_flags |= SA_ONSTACK;
-    sigaction(signum, &st, NULL);
-}
-#endif

--- a/init.h
+++ b/init.h
@@ -2,10 +2,5 @@
 #define CGO_THUMBNAILER_INIT_H
 
 void magickInit();
-static void fixSignal(int signum);
-
-#ifndef SA_ONSTACK
-#define SA_ONSTACK 0x08000000
-#endif
 
 #endif

--- a/main_test.go
+++ b/main_test.go
@@ -255,3 +255,26 @@ func TestWebmAlpha(t *testing.T) {
 		t.Errorf("should contain alpha channel")
 	}
 }
+
+// Called on `go test -args all`
+func TestPanic(t *testing.T) {
+	if len(os.Args) != 2 || os.Args[1] != "all" {
+		t.Skip("Skipping panic test because it's not fixed yet")
+	}
+
+	type B struct {
+		c int
+	}
+	type A struct {
+		b *B
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+
+	a := A{nil}
+	fmt.Println(a.b.c)
+}


### PR DESCRIPTION
- It's no longer required with latest Go, you can correctly catch
  SIGINT/SIGTERM with signal.Notify, see #8

- GM now set SA_ONSTACK on handlers by itself:
  http://hg.code.sf.net/p/graphicsmagick/code/rev/35f6888c781f

- This prevents dead lock (busy loop) on panic/SIGSERV case in
  Go code (e.g. access to member of nil structure); this will be
  reported to GM upstream

Also add currently failing test (disabled by default, use
"go test -args all"). It currently requires patched GM to pass but
hopefully will be fixed in upstream on next release.