### PR TITLE
Add missing import (fixes #76)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,8 @@ RUN apt-get install -y \
 	libswscale-dev
 
 # Install Go
-RUN curl -s \
-	"https://dl.google.com/go/$(curl -s https://golang.org/VERSION?m=text).linux-amd64.tar.gz" \
-	| tar xpz -C /usr/local
+RUN GO_VERSION=$(curl -sSL "https://go.dev/VERSION?m=text" | awk 'NR==1{print $1}') && \
+    curl -sSL "https://dl.google.com/go/${GO_VERSION}.linux-amd64.tar.gz" | tar xpz -C /usr/local
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Try to cache deps

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
 #include <pthread.h>
 
 extern int readCallBack(void*, uint8_t*, int);


### PR DESCRIPTION
Fixes #76 by adding a missing import  to `libavcodec/avcodec.h`. I'd like to know how others have compiled this, and if there's a configuration of ffmpeg that imports this implicitly somehow.